### PR TITLE
created Mock Adapter for unit testing

### DIFF
--- a/tests/mockAdapter.js
+++ b/tests/mockAdapter.js
@@ -1,0 +1,64 @@
+/* This is a mock adapter for unit testing.
+
+To use it, create a Mock Adapter in your test specs like this:
+
+var MockMailAdapter = new MockAdapter('./../adapters/MailAdapter.js');
+
+ */
+
+var mockery= require('mockery');
+
+mockery.enable({warnOnUnregistered: false});	
+	
+var swarmcoreMock = {
+	// This mocked function is called when the actual adapter is loaded
+	createAdapter: function (name) {
+	console.log('Creating Mock Adapter ' + name);
+	}	
+};
+
+mockery.registerMock('swarmcore', swarmcoreMock);
+
+/* 
+Constructor : _file is the adapter module to mock
+ Make sure all functions you want to test are exported from the adapter module
+ via module.exports 
+ */
+function MockAdapter(_file) {
+	
+	this.swarmDetails = {
+		swarmFile: '',
+		phase: '',
+		args: []
+	};
+	
+	var self = this;
+	if (_file) {
+		this.whoami = _file;
+		// This is where the actual adapter is loaded
+		var mockedAdapter = require(_file);
+		Object.keys(mockedAdapter).forEach(function(key) {
+	   		self[key] = mockedAdapter[key]; 
+	 	});
+	}
+}
+
+/* Mock the startSwarm function. */
+MockAdapter.prototype.startSwarm = function(){
+
+// tests can inspect the Mock Adapter's swarmDetails to see if swarms were started.
+
+	this.swarmDetails = {
+		swarmFile: '',
+		phase: '',
+		args: []
+	};
+	
+	for (var i = 0; i < arguments.length; i++) {
+    	if (i === 0) this.swarmDetails.swarmFile = arguments[0];
+		if (i === 1) this.swarmDetails.phase = arguments[1];
+		if (i > 1) this.swarmDetails.args.push(arguments[i]);
+  }
+}
+
+module.exports = MockAdapter; 


### PR DESCRIPTION
For https://github.com/salboaie/SwarmCore/issues/10

This mock adapter relies on the following:

0. Unit testing code in an adapter does not attempt to start the ESB or communicate with redis when it is mocked with this adapter.
1. Adapters must export functions to be tested via modules.export. These functions will be exposed via the mock adapter.
2. The module file of the adapter to be mocked is passed in to the mock adapter constructor as an argument.
3. Side-effects inside the adapter need to be managed.
4. Other modules may need to be mocked for specific adapters. Here is an example of how to do that:

```
var util = require('util');
var MockAdapter = require('./mockAdapter.js');

var mockery = require('mockery');
mockery.enable({warnOnUnregistered: false});	

// Here we mock a module that will attempt to start a mail server in the adapter we want to test
// We don't want to test the mail server.
var mailinMock = {
		start: function (args) {
			console.log('Mocking startup of mail server on Port ' + args.port);
		},
		on: function(args) {
			console.log('Registered Mailin event handler for ' + args);
		}	
	}
	
mockery.registerMock('mailin', mailinMock);
	
// Now that we've mocked the specifics for this adapter, create a Mock Adapter

var MockMailAdapter = new MockAdapter('./../adapters/MailAdapter.js');

module.exports = function() {return MockMailAdapter};
```